### PR TITLE
Can not upgrade stempel plugin from elasticsearch 0.90.5

### DIFF
--- a/src/main/java/org/elasticsearch/indices/analysis/pl/PolishIndicesAnalysis.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/pl/PolishIndicesAnalysis.java
@@ -19,21 +19,18 @@
 
 package org.elasticsearch.indices.analysis.pl;
 
+import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.pl.PolishAnalyzer;
+import org.apache.lucene.analysis.stempel.StempelFilter;
+import org.apache.lucene.analysis.stempel.StempelStemmer;
+import org.egothor.stemmer.Trie;
 import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.analysis.AnalyzerScope;
-import org.elasticsearch.index.analysis.PreBuiltAnalyzerProviderFactory;
-import org.elasticsearch.index.analysis.PreBuiltTokenFilterFactoryFactory;
-import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
-
-import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.stempel.StempelFilter;
-import org.apache.lucene.analysis.stempel.StempelStemmer;
-import org.egothor.stemmer.Trie;
+import org.elasticsearch.indices.analysis.IndicesAnalysisService;
 
 import java.io.IOException;
 
@@ -46,9 +43,9 @@ public class PolishIndicesAnalysis extends AbstractComponent {
     @Inject
     public PolishIndicesAnalysis(Settings settings, IndicesAnalysisService indicesAnalysisService) {
         super(settings);
-        indicesAnalysisService.analyzerProviderFactories().put("polish", new PreBuiltAnalyzerProviderFactory("polish", AnalyzerScope.INDICES, new PolishAnalyzer(Lucene.ANALYZER_VERSION)));
+        indicesAnalysisService.analyzerProviderFactories().put("polish", new StempelAnalyzerProviderFactory("polish", AnalyzerScope.INDICES, new PolishAnalyzer(Lucene.ANALYZER_VERSION)));
 
-        indicesAnalysisService.tokenFilterFactories().put("polish_stem", new PreBuiltTokenFilterFactoryFactory(new TokenFilterFactory() {
+        indicesAnalysisService.tokenFilterFactories().put("polish_stem", new StempelTokenFilterFactoryFactory(new TokenFilterFactory() {
             @Override public String name() {
                 return "polish_stem";
             }

--- a/src/main/java/org/elasticsearch/indices/analysis/pl/StempelAnalyzerProviderFactory.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/pl/StempelAnalyzerProviderFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Elasticsearch (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis.pl;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.AnalyzerProvider;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.PreBuiltAnalyzerProvider;
+import org.elasticsearch.index.analysis.PreBuiltAnalyzerProviderFactory;
+
+public class StempelAnalyzerProviderFactory extends PreBuiltAnalyzerProviderFactory {
+
+    private final PreBuiltAnalyzerProvider analyzerProvider;
+
+    public StempelAnalyzerProviderFactory(String name, AnalyzerScope scope, Analyzer analyzer) {
+        super(name, scope, analyzer);
+        analyzerProvider = new PreBuiltAnalyzerProvider(name, scope, analyzer);
+    }
+
+    @Override
+    public AnalyzerProvider create(String name, Settings settings) {
+        return analyzerProvider;
+    }
+
+    public Analyzer analyzer() {
+        return analyzerProvider.get();
+    }
+}

--- a/src/main/java/org/elasticsearch/indices/analysis/pl/StempelTokenFilterFactoryFactory.java
+++ b/src/main/java/org/elasticsearch/indices/analysis/pl/StempelTokenFilterFactoryFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to Elasticsearch (the "Author") under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. Author licenses this
+ * file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.indices.analysis.pl;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.PreBuiltTokenFilterFactoryFactory;
+import org.elasticsearch.index.analysis.TokenFilterFactory;
+
+public class StempelTokenFilterFactoryFactory extends PreBuiltTokenFilterFactoryFactory {
+    private final TokenFilterFactory tokenFilterFactory;
+
+    public StempelTokenFilterFactoryFactory(TokenFilterFactory tokenFilterFactory) {
+        super(tokenFilterFactory);
+        this.tokenFilterFactory = tokenFilterFactory;
+    }
+
+    @Override
+    public TokenFilterFactory create(String name, Settings settings) {
+        return tokenFilterFactory;
+    }
+}


### PR DESCRIPTION
Due to fix [3790](https://github.com/elasticsearch/elasticsearch/issues/3790) in core, upgrading an analyzer provided as a plugin now fails.

See https://github.com/elasticsearch/elasticsearch/issues/4936 for details.

Issue is in elasticsearch core code but can be fixed in plugins by overloading `PreBuiltTokenFilterFactoryFactory` and `PreBuiltAnalyzerProviderFactory`.

Closes #18.
